### PR TITLE
Fix 'activate' to read 'activated'

### DIFF
--- a/docs/drools-docs/src/main/asciidoc/DroolsRunning-chapter.adoc
+++ b/docs/drools-docs/src/main/asciidoc/DroolsRunning-chapter.adoc
@@ -318,7 +318,7 @@ image::UserGuide/RuleFlowGroup.png[align="center"]
 
 
 A rule flow group is a group of rules associated by the "ruleflow-group" rule attribute.
-These rules can only fire when the group is activate.
+These rules can only fire when the group is activated.
 The group itself can only become active when the elaboration of the ruleflow diagram reaches the node representing the group.
 Here too, the `clear()` method can be called at any time to cancels all matches still remaining on the Agenda.
 


### PR DESCRIPTION
A rule flow group is a group of rules associated by the "ruleflow-group" rule attribute.
These rules can only fire when the group is activate(d).